### PR TITLE
Fix incorrect community display on enter

### DIFF
--- a/src/components/CreateCommunityDialog.tsx
+++ b/src/components/CreateCommunityDialog.tsx
@@ -128,7 +128,7 @@ export const CreateCommunityDialog: React.FC<CreateCommunityDialogProps> = ({
           description: description.trim(),
           category: category.toLowerCase(),
           is_private: isPrivate,
-          owner_id: user.id,
+          creator_id: user.id,
           avatar_url: avatarUrl || null,
           tags: tags,
           member_count: 1

--- a/src/pages/Communities.tsx
+++ b/src/pages/Communities.tsx
@@ -40,7 +40,7 @@ interface Community {
   is_private: boolean;
   category?: string;
   created_at: string;
-  owner_id: string;
+  creator_id: string;
   tags?: string[];
 }
 

--- a/src/pages/CommunityDetail.tsx
+++ b/src/pages/CommunityDetail.tsx
@@ -32,7 +32,7 @@ interface Community {
   is_private: boolean;
   category?: string;
   created_at: string;
-  owner_id: string;
+  creator_id: string;
   tags?: string[];
 }
 
@@ -67,7 +67,7 @@ const CommunityDetail: React.FC = () => {
       }
 
       setCommunity(data);
-      setIsOwner(data.owner_id === user?.id);
+      setIsOwner(data.creator_id === user?.id);
     } catch (err) {
       console.error('Error:', err);
     } finally {

--- a/src/pages/EnhancedCommunities.tsx
+++ b/src/pages/EnhancedCommunities.tsx
@@ -59,7 +59,7 @@ interface Community {
   is_premium?: boolean;
   category?: string;
   created_at: string;
-  owner_id: string;
+  creator_id: string;
   tags?: string[];
   subscription_price?: number;
   features?: string[];
@@ -123,16 +123,7 @@ const EnhancedCommunities: React.FC = () => {
         return;
       }
 
-      // Add mock data for demonstration
-      const enhancedData = (data || []).map(community => ({
-        ...community,
-        is_premium: Math.random() > 0.7,
-        subscription_price: Math.random() > 0.7 ? Math.floor(Math.random() * 20) + 5 : 0,
-        activity_level: ['high', 'medium', 'low'][Math.floor(Math.random() * 3)] as 'high' | 'medium' | 'low',
-        features: ['discussions', 'events', 'leaderboard']
-      }));
-
-      setCommunities(enhancedData);
+      setCommunities(data || []);
     } catch (err) {
       console.error('Unexpected error:', err);
       setError('An unexpected error occurred.');
@@ -312,11 +303,11 @@ const EnhancedCommunities: React.FC = () => {
               </div>
               <div className="flex items-center gap-1 text-gray-600 dark:text-gray-400">
                 <MessageSquare className="w-4 h-4" />
-                <span className="font-medium">{Math.floor(Math.random() * 100)}</span>
+                <span className="font-medium">0</span>
               </div>
               <div className="flex items-center gap-1 text-gray-600 dark:text-gray-400">
                 <Calendar className="w-4 h-4" />
-                <span className="font-medium">{Math.floor(Math.random() * 10)}</span>
+                <span className="font-medium">0</span>
               </div>
             </div>
           </div>
@@ -671,7 +662,7 @@ const EnhancedCommunities: React.FC = () => {
                               </span>
                               <span className="flex items-center gap-1">
                                 <TrendingUp className="w-3 h-3 text-green-500" />
-                                +{Math.floor(Math.random() * 100)}% this week
+                                Growing
                               </span>
                             </div>
                           </div>

--- a/src/pages/EnhancedCommunityDetail.tsx
+++ b/src/pages/EnhancedCommunityDetail.tsx
@@ -51,7 +51,7 @@ interface Community {
   is_premium?: boolean;
   category?: string;
   created_at: string;
-  owner_id: string;
+  creator_id: string;
   tags?: string[];
   subscription_price?: number;
   features?: string[];
@@ -96,44 +96,41 @@ const EnhancedCommunityDetail: React.FC = () => {
     try {
       setLoading(true);
       
-      // Mock community data for demonstration
-      const mockCommunity: Community = {
-        id: id!,
-        name: 'Tech Innovators Hub',
-        description: 'A vibrant community for technology enthusiasts, developers, and innovators. Share ideas, collaborate on projects, and stay updated with the latest tech trends.',
-        avatar_url: '',
-        banner_url: '',
-        member_count: 1234,
-        is_private: false,
-        is_premium: false,
-        category: 'technology',
-        created_at: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString(),
-        owner_id: 'owner123',
-        tags: ['tech', 'innovation', 'development', 'ai', 'web3'],
-        subscription_price: 0,
-        features: ['discussions', 'events', 'leaderboard', 'resources'],
-        rules: `1. Be respectful and professional
+      // Fetch real community data from Supabase
+      const { data, error } = await supabase
+        .from('communities')
+        .select('*')
+        .eq('id', id)
+        .single();
+
+      if (error) {
+        console.error('Error fetching community:', error);
+        toast({
+          title: "Error",
+          description: "Failed to load community details",
+          variant: "destructive"
+        });
+        return;
+      }
+
+      if (data) {
+        setCommunity({
+          ...data,
+          features: data.features || ['discussions', 'events', 'leaderboard', 'resources'],
+          rules: data.rules || `1. Be respectful and professional
 2. No spam or self-promotion without permission
 3. Share knowledge and help others
-4. Keep discussions relevant to technology
+4. Keep discussions relevant
 5. Report inappropriate content`,
-        location: 'Global',
-        website: 'https://techinnovators.com',
-        social_links: {
-          twitter: 'https://twitter.com/techinnovators',
-          discord: 'https://discord.gg/techinnovators',
-          github: 'https://github.com/techinnovators'
-        },
-        stats: {
-          posts_count: 342,
-          events_count: 28,
-          active_members: 456,
-          growth_rate: 15.5
-        }
-      };
-
-      setCommunity(mockCommunity);
-      setIsOwner(user?.id === mockCommunity.owner_id);
+          stats: {
+            posts_count: 0, // These would come from actual post counts
+            events_count: 0,
+            active_members: data.member_count || 0,
+            growth_rate: 0
+          }
+        });
+        setIsOwner(user?.id === data.creator_id);
+      }
     } catch (err) {
       console.error('Error:', err);
       toast({


### PR DESCRIPTION
Remove mock community data and fix `owner_id`/`creator_id` inconsistency to display real community information.

The user reported seeing a "fake community" after creation. This was caused by several components using hardcoded mock data for community details and listings, as well as a mismatch between the `owner_id` field used in the frontend/interfaces and the `creator_id` field in the database, preventing correct data retrieval and display.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb6f7922-a9de-4fa9-9303-665f1cfb44c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cb6f7922-a9de-4fa9-9303-665f1cfb44c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

